### PR TITLE
[feat] 라운팅 동작 코드 분리와 홈 컴포넌트 작업

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,42 +1,8 @@
-import React from 'react';
-import logo from './logo.svg';
-import './App.css';
-import { Route, Routes, Navigate, Link } from 'react-router-dom';
+import Router from './components/Router';
 
 function App() {
   return (
-    <>
-      <ul>
-        <li>
-          <Link to="/">Home</Link>
-        </li> 
-        <li>
-          <Link to="/posts">Post List</Link>
-        </li>
-        <li>
-          <Link to="/posts/:id">Post Detail List</Link>
-        </li>
-        <li>
-          <Link to="/posts/new">Post New</Link>
-        </li>
-        <li>
-          <Link to="/posts/edit/:id">Post Edit</Link>
-        </li>
-        <li>
-          <Link to="/profile">Profile Page</Link>
-        </li>
-      </ul>
-      <Routes>
-        <Route path='/' element={<h1>home page</h1>} />
-        <Route path='/posts' element={<h1>post links page</h1>} />
-        <Route path='/posts/:id' element={<h1>post Detail page</h1>} />
-        <Route path='/posts/new' element={<h1>post New page</h1>} />
-        <Route path='/posts/edit/:id' element={<h1>post Edit page</h1>} />
-        <Route path='/profile' element={<h1>Profile page</h1>} />
-        <Route path="*" element={<Navigate replace to ="/" />} />
-      </Routes>
-
-    </>
+    <Router />
   );
 }
 

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Route, Routes, Navigate, Link } from 'react-router-dom';
+import Home from '../pages/home';
+import PostList from '../pages/posts';
+import PostDetail from '../pages/posts/detail';
+import PostNew from '../pages/posts/new';
+import PostEdit from '../pages/posts/edit';
+import ProfilePage from '../pages/profile';
+import LoginPage from '../pages/login';
+import SignupPage from '../pages/signup';
+
+export default function Router() {
+  return (
+    <>
+      <Routes>
+        <Route path='/' element={<Home />} />
+        <Route path='/posts' element={<PostList />} />
+        <Route path='/posts/:id' element={<PostDetail />} />
+        <Route path='/posts/new' element={<PostNew />} />
+        <Route path='/posts/edit/:id' element={<PostEdit />} />
+        <Route path='/profile' element={<ProfilePage />} />
+        <Route path='/login' element={<LoginPage />} />
+        <Route path='/signup' element={<SignupPage />} />
+        <Route path="*" element={<Navigate replace to ="/" />} />
+      </Routes>
+    </>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,133 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+/* header */
+header {
+  display: flex;
+  justify-content: space-between;
+  flex-direction: row-reverse;
+  border-bottom: 1px solid #f2f2f2;
+  padding: 10px 40px;
+  min-height: 40px;
+  align-items: center;
+}
+
+header a {
+  margin: 0px 10px;
+  text-decoration: none;
+  color: gray;
+}
+
+header a:focus 
+header a:hover {
+  color: black;
+}
+
+/* footer */
+footer {
+  background-color: #f2f2f2;
+  min-height: 40px;
+  padding: 20px 40px;
+  font-size: 14px;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+}
+
+footer a {
+  margin: 0px 10px;
+  text-decoration: none;
+  color: gray;
+}
+
+/* post navigation */
+.post__navigation {
+  display: flex;
+  gap: 12px;
+  margin: 0 auto;
+  max-width: 680px;
+  font-size: 16px;
+  color: gray;
+  cursor: pointer;
+  padding: 48px 20px 0px 20px;
+}
+
+.post__navigation--active {
+  color: black;
+  font-weight: 600;
+}
+
+/* post list */
+.post__list {
+  min-height: 90vh;
+  padding: 20px 40px;
+  text-align: center;
+  max-width: 680px;
+  margin: 0 auto;
+  text-align: left;
+  line-height: 24px;
+}
+
+.post__box {
+  padding-top: 24px;
+  padding-bottom: 24px;
+  border-top: 1px solid #f2f2f2;
+}
+
+.post__profile-box {
+  display: flex;
+  gap: 8px;
+  font-size: 14px;
+  align-items: center;
+}
+
+.post__profile {
+  width: 36px;
+  height: 36px;
+  background-color: #f2f2f2;
+  border-radius: 50%;
+}
+
+.post__author-name,
+.post__date {
+  color: gray;
+  
+}
+
+.post__title {
+  font-size: 20px;
+  font-weight: 600;
+  margin: 14px 0px
+}
+
+.post__text {
+  color: gray;
+  font-size: 16px;
+}
+
+.post__utils-box {
+  display: flex;
+  gap: 8px;
+  flex-direction: row-reverse;
+  font-size: 14px;
+  color: gray;
+}
+
+.post__delete:hover,
+.post__delete:focus {
+  color: black;
+}
+
+.post__edit:hover,
+.post__edit:focus {
+  color: black;
+}
+
+
+.post__list a {
+  text-decoration: none;
+  color: black;
+}

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,0 +1,45 @@
+import { Link } from "react-router-dom";
+
+export default function Home() {
+    return (
+        <div>
+            <header>
+                <div>
+                    <Link to="/posts/new">글쓰기</Link>
+                    <Link to="/posts">게시글</Link>
+                    <Link to="/profile">프로필</Link>
+                </div>
+            </header>
+            <div className="post__navigation">
+                <div className="post__navigation--active">전체</div>
+                <div>나의 글</div>
+            </div>
+            <div className="post__list">
+                {[...Array(10)].map((e, index) => (
+                    <div key={index} className="post__box">
+                        <Link to={`/posts/${index}`}>
+                            <div className="post__profile-box">
+                                <div className="post__profile" />
+                                <div className="post__author-name">패스트 캠퍼스</div>
+                                <div className="post__date">2024.04.10 수요일</div>
+                            </div>
+                            <div className="post__title">게시글 {index}</div>
+                            <div className="post__text">
+                                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+                            </div>
+                            <div className="post__utils-box">
+                                <div className="post__edit">수정</div>
+                                <div className="post__delete">삭제</div>
+                            </div>
+                        </Link>
+                    </div>
+                ))}
+            </div>
+            <footer>
+                <Link to="/posts/new">글쓰기</Link>
+                <Link to="/posts">게시글</Link>
+                <Link to="/profile">프로필</Link>
+            </footer>
+        </div>
+    )
+}

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,0 +1,3 @@
+export default function LoginPage() {
+    return <h2>Login</h2>;
+}

--- a/src/pages/posts/detail.tsx
+++ b/src/pages/posts/detail.tsx
@@ -1,0 +1,3 @@
+export default function PostDetail() {
+    return <h1>post Detail page</h1>;
+}

--- a/src/pages/posts/edit.tsx
+++ b/src/pages/posts/edit.tsx
@@ -1,0 +1,3 @@
+export default function PostEdit() {
+    return <h1>Post Edit page</h1>;
+}

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -1,0 +1,3 @@
+export default function PostList() {
+    return <h1>post links page</h1>;
+}

--- a/src/pages/posts/new.tsx
+++ b/src/pages/posts/new.tsx
@@ -1,0 +1,3 @@
+export default function PostNew() {
+    return <h1>post New page</h1>;
+}

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,0 +1,3 @@
+export default function ProfilePage() {
+    return <h1>Profile page</h1>;
+}

--- a/src/pages/signup/index.tsx
+++ b/src/pages/signup/index.tsx
@@ -1,0 +1,3 @@
+export default function SignupPage() {
+    return <h2>Signup</h2>
+}


### PR DESCRIPTION
- app컴포넌트에서 페이지 라운팅  동작 코드 분리
- 로그인 페이지와 sign up 페이지 추가
- 블로그에 라운팅되는 페이지을 컴포넌트화 작업
- 홈 컴포넌트에 머리글, 바닥글, 게시글 목록 작업과 스타일링 추가
* * *
- 홈 컴포넌트 미리보기
  - 머리글 + 게시글 목록
![image](https://github.com/ssh891123/fastcampus-blog-app/assets/31625851/ffb925f8-aa7f-4a65-b8be-971befec1984)
  - 바닥글 + 게시글 목록
![image](https://github.com/ssh891123/fastcampus-blog-app/assets/31625851/182a15b1-01f7-436a-8f34-1e96db51588d)
